### PR TITLE
Bump pre-commit/pre-commit-hooks from 4.3.0 to 4.4.0

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,5 @@
 <!-- markdownlint-disable-file MD041 -->
 
-Closes #{IssueNumber}
-
 ## Pull request checklist
 
 Please check if your PR fulfills the following requirements:
@@ -48,3 +46,7 @@ Please check the type of change your PR introduces:
 
 <!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
 <!-- This document was adapted from the open-source [appium/appium](https://github.com/appium/appium/blob/master/.github/PULL_REQUEST_TEMPLATE.md) repository. -->
+
+---
+
+Closes #{IssueNumber}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -42,3 +42,7 @@ jobs:
             ${{ steps.changelog.outputs.body }}
           draft: false
           prerelease: false
+      - name: Bump tags
+        uses: fischerscode/tagger@v0
+        with:
+          prefix: v

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -5,7 +5,6 @@ on:
   push:
     tags:
       - 'v*.*.*'
-  pull_request:
 
 jobs:
   create_release:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -5,6 +5,7 @@ on:
   push:
     tags:
       - 'v*.*.*'
+  pull_request:
 
 jobs:
   create_release:

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -15,8 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'windows-latest']
-#        version: ['0.5.3', '0.6', '0.7', '0.8', '0.9']
-        version: ['0.9']
+        version: ['0.5.3', '0.6', '0.7', '0.8', '0.9']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -25,10 +24,5 @@ jobs:
         with:
           version: ${{ matrix.version }}
       - name: Run script (Linux)
-        if: ${{ runner.os == 'Linux' }}
         run: umka ./hello-world.um
-        shell: sh
-      - name: Run script (Windows)
-        if: ${{ runner.os == 'Windows' }}
-        run: umka.exe ./hello-world.um
         shell: sh

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -15,7 +15,8 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'windows-latest']
-        version: ['0.5.3', '0.6', '0.7', '0.8', '0.9']
+#        version: ['0.5.3', '0.6', '0.7', '0.8', '0.9']
+        version: ['0.9']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
         args: ["-c", ".yamllint.yml"]
   # Other
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: check-merge-conflict
       - id: check-json

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This action sets up a [Umka](https://github.com/vtereshkov/umka-lang).
 ## Prerequisites
 
 The following tools have to be installed for successful work of this GitHub action:
-`unzip`, `wget`.
+`unzip`.
 
 > `Windows` and `Linux` are the only supported OS at this moment
 

--- a/action.yml
+++ b/action.yml
@@ -45,7 +45,6 @@ runs:
         tarBall: false
         zipBall: true
         out-file-path: umka
-        token: ${{ secrets.GITHUB_TOKEN }}
     - name: Install umka
       if: ${{ steps.info.outputs.UMKA_INSTALLED == 'false' }}
       run: |

--- a/action.yml
+++ b/action.yml
@@ -34,25 +34,26 @@ runs:
         mkdir -p "$GITHUB_WORKSPACE/umka"
         echo "UMKA_PATH=$GITHUB_WORKSPACE/umka" >> $GITHUB_OUTPUT
       shell: sh
-    - name: Install umka (Linux)
-      if: ${{ runner.os == 'Linux' && steps.info.outputs.UMKA_INSTALLED == 'false' }}
-      env:
-        DOWNLOAD_URL: https://github.com/vtereshkov/umka-lang/releases/download/v${{ inputs.version }}/umka_${{ inputs.version }}_x86-64_${{ steps.info.outputs.UMKA_BINARY }}.zip
+    - name: Download umka
+      if: ${{ steps.info.outputs.UMKA_INSTALLED == 'false' }}
+      uses: robinraju/release-downloader@v1.6
+      with:
+        repository: vtereshkov/umka-lang
+        latest: false
+        tag: v${{ inputs.version }}
+        fileName: umka_${{ inputs.version }}_x86-64_${{ steps.info.outputs.UMKA_BINARY }}.zip
+        tarBall: false
+        zipBall: true
+        out-file-path: umka
+        token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Install umka
+      if: ${{ steps.info.outputs.UMKA_INSTALLED == 'false' }}
       run: |
-        wget -q -O umka.zip $DOWNLOAD_URL && unzip umka.zip && rm -f umka.zip
-        if [ "${{ runner.os }}" = "Linux" ]; then
+        unzip umka.zip
+        rm -f umka.zip
+        if [ "${{ runner.os }}" != "Windows" ]; then
           chmod +x "${{ steps.info.outputs.UMKA_PATH }}/umka_${{ inputs.version }}_x86-64_${{ steps.info.outputs.UMKA_BINARY }}/umka"
         fi
         echo "${{ steps.info.outputs.UMKA_PATH }}/umka_${{ inputs.version }}_x86-64_${{ steps.info.outputs.UMKA_BINARY }}" >> $GITHUB_PATH
       shell: sh
       working-directory: ${{ steps.info.outputs.UMKA_PATH }}
-    - name: Install umka (Windows)
-      if: ${{ runner.os == 'Windows' && steps.info.outputs.UMKA_INSTALLED == 'false' }}
-      env:
-        DOWNLOAD_URL: https://github.com/vtereshkov/umka-lang/releases/download/v${{ inputs.version }}/umka_${{ inputs.version }}_x86-64_${{ steps.info.outputs.UMKA_BINARY }}.zip
-      run: |
-        Invoke-WebRequest -URI $Env:DOWNLOAD_URL -OutFile umka.zip
-        Expand-Archive umka.zip -DestinationPath .
-        Remove-Item -Path umka.zip
-        echo "${{ github.action_path }}umka_${{ inputs.version }}_x86-64_${{ steps.info.outputs.UMKA_BINARY }}" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-      shell: pwsh

--- a/action.yml
+++ b/action.yml
@@ -43,13 +43,13 @@ runs:
         tag: v${{ inputs.version }}
         fileName: umka_${{ inputs.version }}_x86-64_${{ steps.info.outputs.UMKA_BINARY }}.zip
         tarBall: false
-        zipBall: true
+        zipBall: false
         out-file-path: umka
     - name: Install umka
       if: ${{ steps.info.outputs.UMKA_INSTALLED == 'false' }}
       run: |
-        unzip umka.zip
-        rm -f umka.zip
+        unzip umka_${{ inputs.version }}_x86-64_${{ steps.info.outputs.UMKA_BINARY }}.zip
+        rm -f umka_${{ inputs.version }}_x86-64_${{ steps.info.outputs.UMKA_BINARY }}.zip
         if [ "${{ runner.os }}" != "Windows" ]; then
           chmod +x "${{ steps.info.outputs.UMKA_PATH }}/umka_${{ inputs.version }}_x86-64_${{ steps.info.outputs.UMKA_BINARY }}/umka"
         fi


### PR DESCRIPTION
# Changelog

- Update PR template
- Add `fischerscode/tagger`
- Bump `pre-commit/pre-commit-hooks` from _4.3.0_ to _4.4.0_
- Remove `wget` dependency
- Use `robinraju/release-downloader` to download release